### PR TITLE
Update 24 Lab 2c.cpp

### DIFF
--- a/24 Lab 2c.cpp
+++ b/24 Lab 2c.cpp
@@ -13,12 +13,12 @@ int main()
 	source.push(2);
 	source.push(1);
 
-	stack <char> intermediate;
+	stack <int> intermediate;
 	stack <int> destination;
 
 	tower(source.size(), source, destination, intermediate);
 
-	cout << source << "\t" << intermediate.size() << "\t" << destination.size();
+	cout << source.size() << "\t" << intermediate.size() << "\t" << destination.size();
 
 	return 0;
 }


### PR DESCRIPTION
Changed the intermediate's type to int instead of char and edited the output to show the .size() of the source stack. As opposed to the source itself.